### PR TITLE
Fix for ValueError: check_hostname requires server_hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ You can check the disk quota using the above 2 commands. Normally for home it is
 * Open a New Terminal, login into hpc using the ssh command as mentioned in the *Getting Login Access and LOGGING IN* section.
 * Now we need to export the http, ftp and https proxy, Run the command
   ```
-    export http_proxy=10.10.78.XX:3128
+    export http_proxy=http://10.10.78.XX:3128
     export ftp_proxy=10.10.78.XX:3128
-    export https_proxy=10.10.78.XX:3128
+    export https_proxy=http://10.10.78.XX:3128
   ```
   Note that ```XX``` is 22 for B.Tech, 62 for M.Tech and 61 for Ph.D.
 * Now you can install the packages from web using pip commands,


### PR DESCRIPTION
**Issue:** A lot of installations were causing "check_hostname requires server_hostname" ?
**For example:** Even `pip3 install --upgrade pip` was causing `ValueError: check_hostname requires server_hostname`

Fix:
In proxy settings for `https`, I used `http` address is used.

Sources:
1) https://stackoverflow.com/a/69512471/5557585
or 2) https://stackoverflow.com/a/67729676/5557585